### PR TITLE
fixing file name issue with only historical inflows

### DIFF
--- a/R/create_glm_inflow_outflow_files.R
+++ b/R/create_glm_inflow_outflow_files.R
@@ -61,7 +61,7 @@ create_glm_inflow_outflow_files <- function(inflow_file_dir = NULL,
     num_inflows <- max(obs_inflow$inflow_num)
   }
 
-  inflow_file_names <- array(NA, dim = c(length(inflow_files), num_inflows))
+  inflow_file_names <- array(NA, dim = c(max(c(1, length(inflow_files))), num_inflows))
 
   for(j in 1:num_inflows){
 
@@ -120,7 +120,7 @@ create_glm_inflow_outflow_files <- function(inflow_file_dir = NULL,
   }
 
 
-  outflow_file_names <- array(NA, dim = c(length(outflow_files),num_outflows))
+  outflow_file_names <- array(NA, dim = c(max(c(1, length(outflow_files))),num_outflows))
 
 
   for(j in 1:num_outflows){

--- a/tests/testthat/test-suite.R
+++ b/tests/testthat/test-suite.R
@@ -187,8 +187,6 @@ test_that("EnKF can be run", {
                                           obs_config = obs_config
   )
 
-  #saveRDS(enkf_output, file = "/home/rstudio/FLAREr/inst/example/benchmark_data/enkf_output.RDS")
-
   #Load in pre-prepared output
   samp_enkf_output <- readRDS(file.path(test_directory, "benchmark_data/enkf_output.RDS"))
 


### PR DESCRIPTION
There was an issue with generating inflow file names if a list of forecasted inflows was not provided.  