### PR TITLE
extend timeout for edi file download

### DIFF
--- a/R/workflow_functions.R
+++ b/R/workflow_functions.R
@@ -83,7 +83,7 @@ get_edi_file <- function(edi_https, file, lake_directory){ #, curl_timeout = 60)
     if(!dir.exists(dirname(file.path(lake_directory, "data_raw", file)))){
       dir.create(dirname(file.path(lake_directory, "data_raw", file)))
     }
-    url_download <- httr::RETRY("GET",edi_https, httr::timeout(240), pause_base = 5, pause_cap = 20, pause_min = 5, times = 3, quiet = FALSE)
+    url_download <- httr::RETRY("GET",edi_https, httr::timeout(1500), pause_base = 5, pause_cap = 20, pause_min = 5, times = 3, quiet = FALSE)
     test_bin <- httr::content(url_download,'raw')
     writeBin(test_bin, file.path(lake_directory, "data_raw", file))
   }


### PR DESCRIPTION
@rqthomas here is a fix for the lake GLM runs.  I had to significantly increase the timeout value because the downloads were only 20% complete at the 4 minute (240 second) timeout mark. 