### PR TITLE
Fix the generate_met function when there are no gaps

### DIFF
--- a/R/generate_met_files_arrow.R
+++ b/R/generate_met_files_arrow.R
@@ -150,7 +150,7 @@ generate_met_files_arrow <- function(obs_met_file = NULL,
 
 
     if (nrow(n_gaps) > 0) {
-      n_gaps <- ngaps |>
+      n_gaps <- n_gaps |>
         dplyr::summarise(n_gaps = max(.n, na.rm = T)) |> pull()
       message('up to ', n_gaps, ' timesteps of missing data were interpolated per ensemble in stage 3 data')
     }

--- a/R/generate_met_files_arrow.R
+++ b/R/generate_met_files_arrow.R
@@ -146,10 +146,12 @@ generate_met_files_arrow <- function(obs_met_file = NULL,
     n_gaps <- target |>
       dplyr::mutate(time = lubridate::ymd_hm(time)) |>
       tsibble::as_tsibble(index = time, key = ensemble) |>
-      tsibble::count_gaps() |>
-      dplyr::summarise(n_gaps = max(.n, na.rm = T)) |> pull()
+      tsibble::count_gaps()
 
-    if (n_gaps > 0) {
+
+    if (nrow(n_gaps) > 0) {
+      n_gaps <- ngaps |>
+        dplyr::summarise(n_gaps = max(.n, na.rm = T)) |> pull()
       message('up to ', n_gaps, ' timesteps of missing data were interpolated per ensemble in stage 3 data')
     }
 


### PR DESCRIPTION
Me fixing the thing I broke with the last PR. Before if there were no gaps it returned an error and crashed the function. Now it uses an if statement to check for the number of gaps and then runs the summarise function.