### PR TITLE
add error handling for missing met forecasts

### DIFF
--- a/R/generate_met_files_arrow.R
+++ b/R/generate_met_files_arrow.R
@@ -239,10 +239,17 @@ generate_met_files_arrow <- function(obs_met_file = NULL,
     }
   }else{
 
-    forecast <- arrow::open_dataset(forecast_dir) |>
-      dplyr::filter(site_id == lake_name_code) |>
-      dplyr::select(datetime, parameter,variable,prediction) |>
-      dplyr::collect() |>
+    #### test if the forecast directory exists, stop with helpful error if it does not ####
+    tryCatch({
+      forecast <- arrow::open_dataset(forecast_dir) |>
+        dplyr::filter(site_id == lake_name_code) |>
+        dplyr::select(datetime, parameter,variable,prediction) |>
+        dplyr::collect()
+    }, error = function(e) {
+      stop(paste0('NOAA Forecasts were not found for reference_datetime = "',forecast_start_datetime,'"...stopping workflow'))
+    })
+
+    forecast <- forecast |>
       tidyr::pivot_wider(names_from = variable, values_from = prediction) |>
       dplyr::arrange(parameter, datetime) |>
       dplyr::mutate(WindSpeed = sqrt(eastward_wind^2 + northward_wind^2)) |>

--- a/R/run_flare.R
+++ b/R/run_flare.R
@@ -30,6 +30,8 @@ run_flare <- function(lake_directory,
     }
   }
 
+  message('Retrieving Observational Data...')
+
   obs_config <- readr::read_csv(file.path(config$file_path$configuration_directory, config$model_settings$obs_config_file), col_types = readr::cols())
   states_config <- readr::read_csv(file.path(config$file_path$configuration_directory, config$model_settings$states_config_file), col_types = readr::cols())
 
@@ -67,7 +69,11 @@ run_flare <- function(lake_directory,
     config$met$use_hive_met <- TRUE
   }
 
+  message('Generating Met Forecasts...')
+
   if(config$met$use_openmeteo){
+
+    message('Using OpenMeteo Met Drivers...')
 
     met_out <- generate_met_files_openmet(out_dir = config$file_path$execute_directory,
                                           start_datetime = met_start_datetime,
@@ -117,6 +123,7 @@ run_flare <- function(lake_directory,
       variables <- c("time", "FLOW", "TEMP", "SALT")
     }
 
+    message('Creating inflow/outflow files...')
 
     inflow_outflow_files <- FLAREr::create_inflow_outflow_files_arrow(inflow_forecast_dir = inflow_forecast_dir,
                                                                       inflow_obs = file.path(lake_directory, "targets",config$location$site_id, config$inflow$observed_filename),
@@ -157,6 +164,8 @@ run_flare <- function(lake_directory,
                                            forecast_start_datetime = config$run_config$forecast_start_datetime,
                                            forecast_horizon =  config$run_config$forecast_horizon)
 
+  message('Setting states and initial conditions...')
+
   states_config <- FLAREr::generate_states_to_obs_mapping(states_config, obs_config)
 
   model_sd <- FLAREr::initiate_model_error(config, states_config)
@@ -167,6 +176,9 @@ run_flare <- function(lake_directory,
                                               obs,
                                               config,
                                               historical_met_error = met_out$historical_met_error)
+
+  message('Running DA forecast...')
+
   #Run EnKF
   da_forecast_output <- FLAREr::run_da_forecast(states_init = init$states,
                                                 pars_init = init$pars,


### PR DESCRIPTION
@rqthomas I've added a tryCatch() statement that will stop FLARE with a helpful error message whenever there are missing NOAA forecasts for a given reference_datetime.

Also added messages to the run_flare.R script to help track progress and more easily find where the code breaks.